### PR TITLE
Zizmor and trusted publishers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       interval: "daily"
     labels:
       - "Bot"
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,5 +1,8 @@
 name: Publish to PyPI
 
+# no permissions by default
+permissions: {}
+
 on:
   pull_request:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Full Tests
 
+# no permissions by default
+permissions: {}
+
 on:
   pull_request:
   push:
@@ -18,6 +21,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
 
     - name: Setup Micromamba Python ${{ matrix.python-version }}
       uses: mamba-org/setup-micromamba@b09ef9b599704322748535812ca03efb2625677b # v2.0.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,12 @@ repos:
         - requirements-dev.txt
 
 - repo: https://github.com/keewis/blackdoc
-  rev: v0.3.9
+  rev: v0.4.1
   hooks:
     - id: blackdoc
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.1
   hooks:
     - id: codespell
       args:
@@ -44,21 +44,26 @@ repos:
       args: [--config=pyproject.toml]
 
 - repo: https://github.com/asottile/add-trailing-comma
-  rev: v3.1.0
+  rev: v3.2.0
   hooks:
     - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.1
+  rev: v0.12.1
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes", "--config=pyproject.toml"]
     - id: ruff-format
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.4.3
+  rev: v2.6.0
   hooks:
     - id: pyproject-fmt
+
+- repo: https://github.com/woodruffw/zizmor-pre-commit
+  rev: v1.10.0
+  hooks:
+    - id: zizmor
 
 ci:
     autofix_commit_msg: |


### PR DESCRIPTION
The aim of this PR is to make the GitHub Action use a bit safer and implement Trusted Publishers. I'll send similar PRs to all projects that have packages on PyPI.